### PR TITLE
fix: Resolve compilation issues in JSPs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,21 @@
         <jahia-depends>default=8.7</jahia-depends>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <!-- required to use the json taglib (http://www.atg.com/taglibs/json) in the JSPs -->
+            <groupId>atg.taglib.json</groupId>
+            <artifactId>json-taglib</artifactId>
+            <version>0.4.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-el</artifactId>
+                    <groupId>commons-el</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
     <scm>
         <connection>scm:git:git@github.com:Jahia/legacy-default-components.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/legacy-default-components.git</developerConnection>

--- a/src/main/resources/jnt_virtualsite/html/virtualsite.jsp
+++ b/src/main/resources/jnt_virtualsite/html/virtualsite.jsp
@@ -3,6 +3,7 @@
 <%@ page import="org.jahia.registries.ServicesRegistry" %>
 <%@ page import="org.jahia.services.content.JCRNodeWrapper" %>
 <%@ page import="org.jahia.data.templates.JahiaTemplatesPackage" %>
+<%@ page import="org.jahia.services.templates.JahiaTemplateManagerService" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
@@ -80,7 +81,8 @@
 
     <%
         JCRNodeWrapper currentNode = (JCRNodeWrapper) pageContext.findAttribute("currentNode");
-        JahiaTemplatesPackage pack = ServicesRegistry.getInstance().getJahiaTemplateManagerService().getTemplatePackageById(currentNode.getName());
+        JahiaTemplateManagerService templateManagerService = ServicesRegistry.getInstance().getJahiaTemplateManagerService();
+        JahiaTemplatesPackage pack = templateManagerService.getTemplatePackageById(currentNode.getName());
         NodeTypeIterator nti = NodeTypeRegistry.getInstance().getNodeTypes(pack.getId());
         pageContext.setAttribute("nodeTypes",nti);
     %>


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-private/issues/4729.
### Description
Resolve 2 compilation issues in the JSPs:
#### `jnt_virtualsite/html/virtualsite.jsp`

Problem:
```
An error occurred at line: [83] in the jsp file: [/modules/legacy-default-components/jnt_virtualsite/html/virtualsite.jsp]
The type org.jahia.services.templates.JahiaTemplateManagerService cannot be resolved. It is indirectly referenced from required type org.jahia.registries.ServicesRegistry
80: 
81:     <%
82:         JCRNodeWrapper currentNode = (JCRNodeWrapper) pageContext.findAttribute("currentNode");
83:         JahiaTemplatesPackage pack = ServicesRegistry.getInstance().getJahiaTemplateManagerService().getTemplatePackageById(currentNode.getName());
84:         NodeTypeIterator nti = NodeTypeRegistry.getInstance().getNodeTypes(pack.getId());
85:         pageContext.setAttribute("nodeTypes",nti);
86:     %>
```

Solution: Import `org.jahia.services.templates.JahiaTemplateManagerService` in the JSP so it gets added to the list of `Import-Package` in the `MANIFEST.MF`.

#### `jnt_virtualsite/json/virtualsite.languages.jsp`

Problem:
```
/modules/legacy-default-components/jnt_virtualsite/json/virtualsite.languages.jsp (line: [14], column: [0]) Unable to load tag handler class [atg.taglib.json.JsonArrayTag] for tag [json:array]

org.apache.jasper.JasperException: /modules/legacy-default-components/jnt_virtualsite/json/virtualsite.languages.jsp (line: [14], column: [0]) Unable to load tag handler class [atg.taglib.json.JsonArrayTag] for tag [json:array]
```

Solution: embed the `json-taglib` as done in [several places](https://github.com/search?q=org%3AJahia%20%3CartifactId%3Ejson-taglib%3C%2FartifactId%3E&type=code) (for instance in [`default`](https://github.com/Jahia/default/blob/master/pom.xml#L54)).

### Changes for the list of import packages

There is now `org.jahia.services.templates` added to the list of import packages.
Full list:
```
Import-Package
  javax.jcr                              {version=[2.0,3)}
  javax.jcr.nodetype                     {version=[2.0,3)}
  javax.jcr.query.qom                    {version=[2.0,3)}
  javax.servlet.http                     {version=[3.1,4)}
  org.apache.commons.collections         {version=[3.2,4)}
  org.apache.commons.id                  
  org.apache.commons.lang                {version=[2.6,3)}
  org.apache.commons.lang.math           {version=[2.6,3)}
  org.apache.lucene.document             
  org.apache.naming.java                 
  org.apache.solr.client.solrj.response  
  org.apache.solr.schema                 
  org.apache.solr.util                   
  org.apache.taglibs.standard.functions  {version=[1.2,2)}
  org.apache.taglibs.standard.tag.common.core {version=[1.2,2)}
  org.apache.taglibs.standard.tag.rt.core {version=[1.2,2)}
  org.apache.taglibs.standard.tag.rt.fmt {version=[1.2,2)}
  org.apache.taglibs.standard.tei        {version=[1.2,2)}
  org.apache.taglibs.unstandard          {version=[8.2,9)}
  org.jahia.data.templates               
  org.jahia.data.viewhelper.principal    
  org.jahia.defaults.config.spring       
  org.jahia.exceptions                   
  org.jahia.registries                   
  org.jahia.services                     
  org.jahia.services.channels            
  org.jahia.services.channels.filters    
  org.jahia.services.content             
  org.jahia.services.content.decorator   
  org.jahia.services.content.nodetypes   
  org.jahia.services.content.nodetypes.renderer 
  org.jahia.services.query               
  org.jahia.services.render              
  org.jahia.services.render.scripting    
  org.jahia.services.seo                 
  org.jahia.services.templates           
  org.jahia.services.usermanager         
  org.jahia.settings                     
  org.jahia.taglibs                      {version=[8.2,9)}
  org.jahia.taglibs.facet                {version=[8.2,9)}
  org.jahia.taglibs.functions            {version=[8.2,9)}
  org.jahia.taglibs.internal.date        {version=[8.2,9)}
  org.jahia.taglibs.jcr                  {version=[8.2,9)}
  org.jahia.taglibs.jcr.node             {version=[8.2,9)}
  org.jahia.taglibs.jcr.query            {version=[8.2,9)}
  org.jahia.taglibs.query                {version=[8.2,9)}
  org.jahia.taglibs.template             {version=[8.2,9)}
  org.jahia.taglibs.template.gwt         {version=[8.2,9)}
  org.jahia.taglibs.template.include     {version=[8.2,9)}
  org.jahia.taglibs.template.layoutmanager {version=[8.2,9)}
  org.jahia.taglibs.template.pager       {version=[8.2,9)}
  org.jahia.taglibs.uicomponents         {version=[8.2,9)}
  org.jahia.taglibs.uicomponents.i18n    {version=[8.2,9)}
  org.jahia.taglibs.uicomponents.image   {version=[8.2,9)}
  org.jahia.taglibs.uicomponents.loginform {version=[8.2,9)}
  org.jahia.taglibs.user                 {version=[8.2,9)}
  org.jahia.taglibs.utility              {version=[8.2,9)}
  org.jahia.taglibs.utility.constants    {version=[8.2,9)}
  org.jahia.taglibs.utility.i18n         {version=[8.2,9)}
  org.jahia.taglibs.utility.session      {version=[8.2,9)}
  org.jahia.taglibs.utility.siteproperties {version=[8.2,9)}
  org.jahia.taglibs.workflow             {version=[8.2,9)}
  org.jahia.utils    
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
