### PR TITLE
chore: bump jahia parent from 8.2.0.0 to 8.2.4.0

### DIFF
--- a/.chachalog/jwW9_stg.md
+++ b/.chachalog/jwW9_stg.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+legacy-default-components: major
+---
+
+Bump jahia parent from 8.2.0.0 to 8.2.4.0 to avoid views conflicts with previous jahia versions (#43)

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.4.0</version>
+        <version>8.2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>legacy-default-components</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <artifactId>legacy-default-components</artifactId>
     <name>Legacy Default Components</name>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>bundle</packaging>
     <description>This is a module that contains legacy components previously provided by module (default).</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <version>8.2.4.0</version>
     </parent>
 
     <artifactId>legacy-default-components</artifactId>


### PR DESCRIPTION
Closes https://github.com/Jahia/legacy-default-components/issues/42

**update:**
changes were reverted and reapplied afterwards to follow the proper process (see https://github.com/Jahia/legacy-default-components/pull/45)