### PR TITLE
chore: bump jahia parent from 8.2.0.0 to 8.2.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <version>8.2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>legacy-default-components</artifactId>
     <name>Legacy Default Components</name>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is a module that contains legacy components previously provided by module (default).</description>
 


### PR DESCRIPTION
Closes https://github.com/Jahia/legacy-default-components/issues/42
Since several components were moved from `default` module to this one, major digit was bumped in the module's version to reflect non-backward-compatible changes.
