### PR TITLE
fix: consistently escape special characters in legacy default component labels

### DIFF
--- a/.chachalog/c8Wm4pQz.md
+++ b/.chachalog/c8Wm4pQz.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+legacy-default-components: patch
+---
+
+Fixed display of editor-set text and attribute values containing special characters across the legacy default components views (button/popup, author, metadata, video).

--- a/src/main/resources/jnt_authorDisplay/html/authorDisplay.jsp
+++ b/src/main/resources/jnt_authorDisplay/html/authorDisplay.jsp
@@ -22,10 +22,10 @@
 <c:set var="mainTemplate" value="${currentNode.properties['j:userView'].string}"/>
 <c:choose>
     <c:when test="${renderContext.editMode}">
-        <div class="authorDisplayArea<c:if test="${not empty currentNode.properties['j:mockupStyle']}"> ${currentNode.properties['j:mockupStyle'].string}</c:if>">
+        <div class="authorDisplayArea<c:if test="${not empty currentNode.properties['j:mockupStyle']}"> ${fn:escapeXml(currentNode.properties['j:mockupStyle'].string)}</c:if>">
             <c:if test="${not empty currentNode.properties['j:userView'].string}">
                 <div class="authorDisplayTemplate">
-                    <span>${currentNode.properties['j:userView'].string}</span>
+                    <span><c:out value="${currentNode.properties['j:userView'].string}"/></span>
                 </div>
             </c:if>
         </div>

--- a/src/main/resources/jnt_displayMetadata/html/displayMetadata.jsp
+++ b/src/main/resources/jnt_displayMetadata/html/displayMetadata.jsp
@@ -33,7 +33,7 @@
             </c:if>
             <c:if test="${props.creator.boolean}">
                     <dt><fmt:message key="mix_created.jcr_createdBy"/></dt>
-                    <dd>${boundComponent.properties['jcr:createdBy'].string}</dd>
+                    <dd><c:out value="${boundComponent.properties['jcr:createdBy'].string}"/></dd>
             </c:if>
             <c:if test="${props.lastmodification.boolean}">
                     <dt><fmt:message key="mix_lastModified.jcr_lastModified"/></dt>
@@ -42,7 +42,7 @@
             </c:if>
             <c:if test="${props.lastcontributor.boolean}">
                     <dt><fmt:message key="mix_lastModified.jcr_lastModifiedBy"/></dt>
-                    <dd>${boundComponent.properties['jcr:lastModifiedBy'].string}</dd>
+                    <dd><c:out value="${boundComponent.properties['jcr:lastModifiedBy'].string}"/></dd>
             </c:if>
             <c:if test="${props.description.boolean}">
                     <dt><fmt:message key="mix_title.jcr_description"/></dt>

--- a/src/main/resources/jnt_openInPopup/html/openInPopup.jsp
+++ b/src/main/resources/jnt_openInPopup/html/openInPopup.jsp
@@ -14,7 +14,7 @@
 </script>
 <c:if test="${not renderContext.editMode}">
 <div style="display:none">
-    <div id="popup-${currentNode.name}" class="${currentNode.properties['popupClass'].string}">
+    <div id="popup-${currentNode.name}" class="${fn:escapeXml(currentNode.properties['popupClass'].string)}">
 </c:if>
 <c:forEach items="${jcr:getChildrenOfType(currentNode,'jmix:droppableContent')}" var="child">
     <template:module path="${child.path}"/>
@@ -26,5 +26,5 @@
     </div>
 </div>
 </c:if>
-<a class="${currentNode.properties['buttonClass'].string}" id="openPopup-${currentNode.name}"
-href="#popup-${currentNode.name}">${currentNode.properties['buttonLabel'].string}</a>
+<a class="${fn:escapeXml(currentNode.properties['buttonClass'].string)}" id="openPopup-${currentNode.name}"
+href="#popup-${currentNode.name}"><c:out value="${currentNode.properties['buttonLabel'].string}"/></a>

--- a/src/main/resources/jnt_video/html/video.jsp
+++ b/src/main/resources/jnt_video/html/video.jsp
@@ -36,7 +36,7 @@
 
 <video id="video-${currentNode.identifier}" class="video-js vjs-default-skin" controls <c:if test="${currentNode.properties.autoplay.boolean and not renderContext.editMode}">autoplay</c:if>
        preload="${renderContext.editMode ? "metadata" : "auto"}"
-       width="${currentNode.properties.width.string}" height="${currentNode.properties.height.string}"
+       width="${fn:escapeXml(currentNode.properties.width.string)}" height="${fn:escapeXml(currentNode.properties.height.string)}"
        data-setup='{"techOrder":["html5"]}'>
   <source src="${source.url}" type='${mimeType.string == "video/x-f4v" ? "video/mp4" : mimeType.string}' />
 </video>


### PR DESCRIPTION
### Summary
Several legacy-default-components views printed editor-controlled String properties (button labels/classes, popup classes, video dimensions, author/metadata fields) **without escaping**, so values containing special characters (`<`, `>`, `&`, quotes) could be rendered incorrectly on the delivered (guest) page.

### Change
Applied **context-correct** output escaping:
- HTML-attribute sinks (`popupClass`, `buttonClass`, `j:mockupStyle`, video `width`/`height`) → `${fn:escapeXml(...)}`
- HTML-text sinks (`buttonLabel`, `jcr:createdBy`, `jcr:lastModifiedBy`, `j:userView`) → `<c:out value="..."/>`

`displayMetadata.jsp` sibling properties were already escaped; only the still-raw lines changed. The `fn` taglib was already declared in each file; no-op for plain-text values.

### Verification
Deploy-tested on a local 8.2.x instance with a clean **before/after** (guest render): the baseline build rendered the values raw; this branch renders them correctly escaped across all affected views.

> Note: the `tagCloud` view lives in a separate module (not this repo) and needs a JS-string-context fix — tracked separately.
